### PR TITLE
Overlap issues for wider frames 

### DIFF
--- a/lambeq/backend/drawing/drawable.py
+++ b/lambeq/backend/drawing/drawable.py
@@ -891,9 +891,12 @@ class DrawableDiagramWithFrames(DrawableDiagram):
 
             left_frame_end = outer_box.x - (outer_box.w / 2)
             pad = rightmost_edge + BOX_SPACING - left_frame_end
-            for node in self.boxes + self.wire_endpoints:
-                if node.parent is None and node not in components_to_left:
-                    node._apply_drawing_offset((pad, 0))
+            # always shift components to right as left part is already sorted,
+            # when padding -ve the components will be moved to left, which creates overlap
+            if pad > 0:
+                for node in self.boxes + self.wire_endpoints:
+                    if node.parent is None and node not in components_to_left:
+                        node._apply_drawing_offset((pad, 0))
 
         # if off and (self.wire_endpoints[scan[off - 1]].x
         #             > left_frame_end - X_SPACING):


### PR DESCRIPTION
this patch fixes few issues reported earlier.  while adding new frames, tries to shift components right side of the current frame. sometimes the padding gets a negative value, which makes the components moved to left and overlapping. 

1. Floating frames

<img width="1159" alt="Screenshot 2024-11-01 at 19 25 59" src="https://github.com/user-attachments/assets/f3461dac-a203-46a4-80c7-faffbf1ea12a">

2.  Some frames still overlap

<img width="1164" alt="Screenshot 2024-11-01 at 19 27 13" src="https://github.com/user-attachments/assets/571bd199-d208-4476-b4d9-74f2103ab9c7">
